### PR TITLE
CORE-2447 make commands aware of exact stores to run in

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,4 @@
 parameters:
-  bootstrap: %rootDir%/../../../phpstan-bootstrap.php
+    bootstrap: %rootDir%/../../../phpstan-bootstrap.php
+    ignoreErrors:
+        - '#Function getenv invoked with 0 parameters, 1-2 required#'

--- a/src/Spryker/Install/Configuration/Builder/Section/Command/CommandBuilder.php
+++ b/src/Spryker/Install/Configuration/Builder/Section/Command/CommandBuilder.php
@@ -56,6 +56,7 @@ class CommandBuilder implements CommandBuilderInterface
         $this->setGroups($command, $definition);
         $this->setEnv($command, $definition);
         $this->setIsStoreAware($command, $definition);
+        $this->setStores($command, $definition);
         $this->addCommandConditions($command, $definition);
         $this->setPreCommand($command, $definition);
         $this->setPostCommand($command, $definition);
@@ -112,8 +113,31 @@ class CommandBuilder implements CommandBuilderInterface
     protected function setIsStoreAware(CommandInterface $command, array $definition)
     {
         if (isset($definition[static::CONFIG_STORES])) {
-            $command->setIsStoreAware($definition[static::CONFIG_STORES]);
+            $command->setIsStoreAware($this->getIsStoreAware($definition));
         }
+    }
+
+    /**
+     * @param \Spryker\Install\Stage\Section\Command\CommandInterface $command
+     * @param array $definition
+     *
+     * @return void
+     */
+    protected function setStores(CommandInterface $command, array $definition)
+    {
+        if (isset($definition[static::CONFIG_STORES]) && is_array($definition[static::CONFIG_STORES])) {
+            $command->setStores($definition[static::CONFIG_STORES]);
+        }
+    }
+
+    /**
+     * @param array $definition
+     *
+     * @return bool
+     */
+    protected function getIsStoreAware(array $definition)
+    {
+        return (is_array($definition[static::CONFIG_STORES])) ? true : $definition[static::CONFIG_STORES];
     }
 
     /**

--- a/src/Spryker/Install/Configuration/Builder/Section/Command/CommandBuilder.php
+++ b/src/Spryker/Install/Configuration/Builder/Section/Command/CommandBuilder.php
@@ -118,6 +118,16 @@ class CommandBuilder implements CommandBuilderInterface
     }
 
     /**
+     * @param array $definition
+     *
+     * @return bool
+     */
+    protected function getIsStoreAware(array $definition)
+    {
+        return (is_array($definition[static::CONFIG_STORES])) ? true : $definition[static::CONFIG_STORES];
+    }
+
+    /**
      * @param \Spryker\Install\Stage\Section\Command\CommandInterface $command
      * @param array $definition
      *
@@ -128,16 +138,6 @@ class CommandBuilder implements CommandBuilderInterface
         if (isset($definition[static::CONFIG_STORES]) && is_array($definition[static::CONFIG_STORES])) {
             $command->setStores($definition[static::CONFIG_STORES]);
         }
-    }
-
-    /**
-     * @param array $definition
-     *
-     * @return bool
-     */
-    protected function getIsStoreAware(array $definition)
-    {
-        return (is_array($definition[static::CONFIG_STORES])) ? true : $definition[static::CONFIG_STORES];
     }
 
     /**

--- a/src/Spryker/Install/Executable/CommandLine/CommandLineExecutable.php
+++ b/src/Spryker/Install/Executable/CommandLine/CommandLineExecutable.php
@@ -44,6 +44,7 @@ class CommandLineExecutable implements ExecutableInterface
     public function execute(StyleInterface $output): int
     {
         $process = new Process($this->command->getExecutable(), SPRYKER_ROOT, getenv(), null, 600);
+        $process->inheritEnvironmentVariables(true);
         $process->start();
 
         foreach ($process as $buffer) {

--- a/src/Spryker/Install/Runner/Section/Command/CommandRunner.php
+++ b/src/Spryker/Install/Runner/Section/Command/CommandRunner.php
@@ -98,11 +98,26 @@ class CommandRunner implements CommandRunnerInterface
             return;
         }
 
-        foreach ($configuration->getExecutableStores() as $store) {
+        foreach ($this->getExecutableStoresForCommand($command, $configuration) as $store) {
             $this->environmentHelper->putEnv('APPLICATION_STORE', $store);
             $this->executeExecutable($executable, $command, $configuration, $store);
             $this->environmentHelper->unsetEnv('APPLICATION_STORE');
         }
+    }
+
+    /**
+     * @param \Spryker\Install\Stage\Section\Command\CommandInterface $command
+     * @param \Spryker\Install\Configuration\ConfigurationInterface $configuration
+     *
+     * @return string[]
+     */
+    protected function getExecutableStoresForCommand(CommandInterface $command, ConfigurationInterface $configuration): array
+    {
+        if (!$command->hasStores()) {
+            return $configuration->getExecutableStores();
+        }
+
+        return array_intersect($configuration->getExecutableStores(), $command->getStores());
     }
 
     /**

--- a/src/Spryker/Install/Stage/Section/Command/Command.php
+++ b/src/Spryker/Install/Stage/Section/Command/Command.php
@@ -62,6 +62,11 @@ class Command implements CommandInterface
     protected $breakOnFailure = true;
 
     /**
+     * @var string[]
+     */
+    protected $stores = [];
+
+    /**
      * @param string $name
      */
     public function __construct(string $name)
@@ -147,6 +152,34 @@ class Command implements CommandInterface
     public function isStoreAware(): bool
     {
         return $this->isStoreAware;
+    }
+
+    /**
+     * @param string[] $stores
+     *
+     * @return \Spryker\Install\Stage\Section\Command\CommandInterface
+     */
+    public function setStores(array $stores): CommandInterface
+    {
+        $this->stores = $stores;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getStores(): array
+    {
+        return $this->stores;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasStores(): bool
+    {
+        return (count($this->stores) > 0);
     }
 
     /**

--- a/src/Spryker/Install/Stage/Section/Command/CommandInterface.php
+++ b/src/Spryker/Install/Stage/Section/Command/CommandInterface.php
@@ -60,6 +60,23 @@ interface CommandInterface
     public function isStoreAware(): bool;
 
     /**
+     * @param string[] $stores
+     *
+     * @return $this
+     */
+    public function setStores(array $stores): self;
+
+    /**
+     * @return string[]
+     */
+    public function getStores(): array;
+
+    /**
+     * @return bool
+     */
+    public function hasStores(): bool;
+
+    /**
      * @param \Spryker\Install\Stage\Section\Command\Condition\ConditionInterface $condition
      *
      * @return $this

--- a/tests/SprykerTest/Console/InstallConsoleCommandStoresTest.php
+++ b/tests/SprykerTest/Console/InstallConsoleCommandStoresTest.php
@@ -39,9 +39,12 @@ class InstallConsoleCommandStoresTest extends Unit
         $tester->execute($arguments);
 
         $output = $tester->getDisplay();
-        $this->assertRegexp('/Command section-a-command-a for DE store/', $output, 'Command "section-a-command-a" was expected to be executed for DE but was not');
-        $this->assertRegexp('/Command section-a-command-a for AT store/', $output, 'Command "section-a-command-a" was expected to be executed for AT but was not');
-        $this->assertRegexp('/Command section-a-command-a for US store/', $output, 'Command "section-a-command-a" was expected to be executed for US but was not');
+        $this->assertRegexp('/Command section-a-command-a for DE store/', $output, 'Command "section-a-command-a" was expected to be executed for DE store but was not');
+        $this->assertRegexp('/Command section-a-command-a for AT store/', $output, 'Command "section-a-command-a" was expected to be executed for AT store but was not');
+        $this->assertRegexp('/Command section-a-command-a for US store/', $output, 'Command "section-a-command-a" was expected to be executed for US store but was not');
+
+        $this->assertRegexp('/Command section-b-command-a for DE store/', $output, 'Command "section-b-command-a" was expected to be executed for DE store but was not');
+        $this->assertRegexp('/Command section-b-command-a for AT store/', $output, 'Command "section-b-command-a" was expected to be executed for AT store but was not');
     }
 
     /**
@@ -63,6 +66,33 @@ class InstallConsoleCommandStoresTest extends Unit
         $this->assertRegexp('/Command section-a-command-a for DE store/', $output, 'Command "section-a-command-a" was expected to be executed for DE store but was not');
         $this->assertNotRegexp('/Command section-a-command-a for US store/', $output, 'Command "section-a-command-a" was not expected to be executed for AT store but was');
         $this->assertNotRegexp('/Command section-a-command-a for US store/', $output, 'Command "section-a-command-a" was not expected to be executed for US store but was');
+
+        $this->assertRegexp('/Command section-b-command-a for DE store/', $output, 'Command "section-b-command-a" was expected to be executed for DE store but was not');
+        $this->assertNotRegexp('/Command section-b-command-a for US store/', $output, 'Command "section-b-command-a" was not expected to be executed for AT store but was');
+        $this->assertNotRegexp('/Command section-b-command-a for US store/', $output, 'Command "section-b-command-a" was not expected to be executed for US store but was');
+    }
+
+    /**
+     * @return void
+     */
+    public function testOnlyCommandsWhichAreAwareOfRequestedStoreAreExecuted()
+    {
+        $command = new InstallConsoleCommand();
+        $tester = $this->tester->getCommandTester($command);
+
+        $arguments = [
+            'command' => $command->getName(),
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            InstallConsoleCommand::ARGUMENT_STORE => 'US',
+        ];
+        $tester->execute($arguments);
+
+        $output = $tester->getDisplay();
+        $this->assertRegexp('/Command section-a-command-a for US store/', $output, 'Command "section-a-command-a" was expected to be executed for US store but was not');
+        $this->assertNotRegexp('/Command section-a-command-a for DE store/', $output, 'Command "section-a-command-a" was not expected to be executed for DE store but was');
+        $this->assertNotRegexp('/Command section-a-command-a for AT store/', $output, 'Command "section-a-command-a" was not expected to be executed for AT store but was');
+
+        $this->assertNotRegexp('/Command section-b-command-a for US store/', $output, 'Command "section-b-command-a" was not expected to be executed for US store but was');
     }
 
     /**
@@ -75,7 +105,7 @@ class InstallConsoleCommandStoresTest extends Unit
 
         $arguments = [
             'command' => $command->getName(),
-            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores-interactive',
             '--' . InstallConsoleCommand::OPTION_INTERACTIVE => true,
         ];
         $tester->setInputs([1, 'yes']);
@@ -97,7 +127,7 @@ class InstallConsoleCommandStoresTest extends Unit
 
         $arguments = [
             'command' => $command->getName(),
-            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores-interactive',
             '--' . InstallConsoleCommand::OPTION_INTERACTIVE => true,
         ];
         $tester->setInputs(['DE', 'yes']);
@@ -119,7 +149,7 @@ class InstallConsoleCommandStoresTest extends Unit
 
         $arguments = [
             'command' => $command->getName(),
-            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores-interactive',
             '--' . InstallConsoleCommand::OPTION_INTERACTIVE => true,
         ];
         $tester->setInputs(['1,2', 'yes']);
@@ -141,7 +171,7 @@ class InstallConsoleCommandStoresTest extends Unit
 
         $arguments = [
             'command' => $command->getName(),
-            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores-interactive',
             '--' . InstallConsoleCommand::OPTION_INTERACTIVE => true,
         ];
         $tester->setInputs(['DE,AT', 'yes']);
@@ -163,7 +193,7 @@ class InstallConsoleCommandStoresTest extends Unit
 
         $arguments = [
             'command' => $command->getName(),
-            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores-interactive',
             '--' . InstallConsoleCommand::OPTION_INTERACTIVE => true,
         ];
         $tester->setInputs([0, 'yes']);
@@ -185,7 +215,7 @@ class InstallConsoleCommandStoresTest extends Unit
 
         $arguments = [
             'command' => $command->getName(),
-            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores',
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'stores-interactive',
             '--' . InstallConsoleCommand::OPTION_INTERACTIVE => true,
         ];
         $tester->setInputs(['all', 'yes']);

--- a/tests/_data/config/install/stores-interactive.yml
+++ b/tests/_data/config/install/stores-interactive.yml
@@ -8,10 +8,3 @@ sections:
     section-a-command-a:
       command: "echo hello"
       stores: true
-
-  section-b:
-    section-b-command-a:
-      command: "echo hello"
-      stores:
-        - DE
-        - AT


### PR DESCRIPTION
Allow defining for which stores a command should run. Previously we had only `stores: true` which will run the command than with all configured stores.

Now it's possible to also use an array and not only a boolean.

With 
```
stores:
  - DE
  - AT
```
The install will run only for DE and AT and not for any other configured store. 