### PR TITLE
CORE-3422 allow to configure timeout per command.

### DIFF
--- a/src/Spryker/Install/Configuration/Builder/Section/Command/CommandBuilder.php
+++ b/src/Spryker/Install/Configuration/Builder/Section/Command/CommandBuilder.php
@@ -22,6 +22,7 @@ class CommandBuilder implements CommandBuilderInterface
     const CONFIG_POST_COMMAND = 'post';
     const CONFIG_CONDITIONS = 'conditions';
     const CONFIG_BREAK_ON_FAILURE = 'breakOnFailure';
+    const CONFIG_TIMEOUT = 'timeout';
 
     /**
      * @var \Spryker\Install\Stage\Section\Command\CommandInterface
@@ -61,6 +62,7 @@ class CommandBuilder implements CommandBuilderInterface
         $this->setPreCommand($command, $definition);
         $this->setPostCommand($command, $definition);
         $this->setBreakOnFailure($command, $definition);
+        $this->setTimeout($command, $definition);
 
         return $command;
     }
@@ -194,6 +196,19 @@ class CommandBuilder implements CommandBuilderInterface
     {
         if (isset($definition[static::CONFIG_BREAK_ON_FAILURE])) {
             $command->setBreakOnFailure($definition[static::CONFIG_BREAK_ON_FAILURE]);
+        }
+    }
+
+    /**
+     * @param \Spryker\Install\Stage\Section\Command\CommandInterface $command
+     * @param array $definition
+     *
+     * @return void
+     */
+    protected function setTimeout(CommandInterface $command, array $definition)
+    {
+        if (isset($definition[static::CONFIG_TIMEOUT])) {
+            $command->setTimeout($definition[static::CONFIG_TIMEOUT]);
         }
     }
 }

--- a/src/Spryker/Install/Executable/CommandLine/CommandLineExecutable.php
+++ b/src/Spryker/Install/Executable/CommandLine/CommandLineExecutable.php
@@ -16,6 +16,8 @@ use Symfony\Component\Process\Process;
 
 class CommandLineExecutable implements ExecutableInterface
 {
+    const DEFAULT_TIMEOUT_IN_SECONDS = 600;
+
     /**
      * @var \Spryker\Install\Stage\Section\Command\CommandInterface
      */
@@ -43,7 +45,7 @@ class CommandLineExecutable implements ExecutableInterface
      */
     public function execute(StyleInterface $output): int
     {
-        $process = new Process($this->command->getExecutable(), SPRYKER_ROOT, getenv(), null, 600);
+        $process = $this->buildProcess();
         $process->inheritEnvironmentVariables(true);
         $process->start();
 
@@ -56,6 +58,32 @@ class CommandLineExecutable implements ExecutableInterface
         }
 
         return ($process->getExitCode() === null) ? static::CODE_SUCCESS : $process->getExitCode();
+    }
+
+    /**
+     * @return \Symfony\Component\Process\Process
+     */
+    protected function buildProcess()
+    {
+        return new Process(
+            $this->command->getExecutable(),
+            SPRYKER_ROOT,
+            getenv(),
+            null,
+            $this->getProcessTimeout()
+        );
+    }
+
+    /**
+     * @return int
+     */
+    protected function getProcessTimeout()
+    {
+        if ($this->command->hasTimeout()) {
+            return $this->command->getTimeout();
+        }
+
+        return static::DEFAULT_TIMEOUT_IN_SECONDS;
     }
 
     /**

--- a/src/Spryker/Install/Stage/Section/Command/Command.php
+++ b/src/Spryker/Install/Stage/Section/Command/Command.php
@@ -67,6 +67,11 @@ class Command implements CommandInterface
     protected $stores = [];
 
     /**
+     * @var int
+     */
+    protected $timeout = 0;
+
+    /**
      * @param string $name
      */
     public function __construct(string $name)
@@ -294,5 +299,33 @@ class Command implements CommandInterface
     public function breakOnFailure(): bool
     {
         return $this->breakOnFailure;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasTimeout(): bool
+    {
+        return ($this->timeout !== 0);
+    }
+
+    /**
+     * @param int $timeout
+     *
+     * @return \Spryker\Install\Stage\Section\Command\CommandInterface
+     */
+    public function setTimeout(int $timeout): CommandInterface
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getTimeout(): int
+    {
+        return $this->timeout;
     }
 }

--- a/src/Spryker/Install/Stage/Section/Command/CommandInterface.php
+++ b/src/Spryker/Install/Stage/Section/Command/CommandInterface.php
@@ -143,4 +143,21 @@ interface CommandInterface
      * @return bool
      */
     public function breakOnFailure(): bool;
+
+    /**
+     * @return bool
+     */
+    public function hasTimeout(): bool;
+
+    /**
+     * @param int $timeout
+     *
+     * @return $this
+     */
+    public function setTimeout(int $timeout): self;
+
+    /**
+     * @return int
+     */
+    public function getTimeout(): int;
 }

--- a/tests/SprykerTest/Console/InstallConsoleCommandCommandTest.php
+++ b/tests/SprykerTest/Console/InstallConsoleCommandCommandTest.php
@@ -10,6 +10,7 @@ namespace SprykerTest\Console;
 use Codeception\Test\Unit;
 use Spryker\Console\InstallConsoleCommand;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
 /**
  * Auto-generated group annotations
@@ -42,5 +43,41 @@ class InstallConsoleCommandCommandTest extends Unit
 
         $output = $tester->getDisplay();
         $this->assertNotRegexp('/Command section-a-command-a/', $output, 'Command "section-a-command-a" was not expected to be executed but was');
+    }
+
+    /**
+     * @return void
+     */
+    public function testRunsCommandWithSpecifiedTimeout()
+    {
+        $command = new InstallConsoleCommand();
+        $tester = $this->tester->getCommandTester($command);
+
+        $arguments = [
+            'command' => $command->getName(),
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'timeout',
+            '--' . InstallConsoleCommand::OPTION_EXCLUDE => ['section-a-command-b'],
+        ];
+        $tester->execute($arguments, ['verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
+
+        $output = $tester->getDisplay();
+        $this->assertRegexp('/Command section-a-command-a/', $output, 'Command "section-a-command-a" was expected to run properly but was not.');
+    }
+
+    /**
+     * @return void
+     */
+    public function testThrowsExceptionWhenCommandRunsLongerThanConfiguredTimeout()
+    {
+        $command = new InstallConsoleCommand();
+        $tester = $this->tester->getCommandTester($command);
+
+        $arguments = [
+            'command' => $command->getName(),
+            '--' . InstallConsoleCommand::OPTION_RECIPE => 'timeout',
+        ];
+
+        $this->expectException(ProcessTimedOutException::class);
+        $tester->execute($arguments, ['verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
     }
 }

--- a/tests/_data/config/install/timeout.yml
+++ b/tests/_data/config/install/timeout.yml
@@ -1,0 +1,9 @@
+sections:
+  section-a:
+    section-a-command-a:
+      command: "echo 'runs normal'"
+      timeout: 20
+
+    section-a-command-b:
+      command: "sleep 2"
+      timeout: 1


### PR DESCRIPTION
Previously it was not possible to run commands which had a execution time higher than 600 secs. Now each command can be configured to have its own timeout.