### PR TITLE
CORE-4307 Configure default command timeout per recipe

### DIFF
--- a/src/Spryker/Install/Configuration/Builder/ConfigurationBuilder.php
+++ b/src/Spryker/Install/Configuration/Builder/ConfigurationBuilder.php
@@ -28,6 +28,7 @@ class ConfigurationBuilder implements ConfigurationBuilderInterface
     const CONFIG_EXCLUDED = 'excluded';
     const CONFIG_ENV = 'env';
     const CONFIG_STORES = 'stores';
+    const CONFIG_COMMAND_TIMEOUT = 'command-timeout';
     const CONFIG_GROUPS = 'groups';
     const CONFIG_CONDITIONS = 'conditions';
     const CONFIG_PRE_COMMAND = 'pre';
@@ -112,6 +113,7 @@ class ConfigurationBuilder implements ConfigurationBuilderInterface
 
         $this->setEnv($configuration);
         $this->setStores($configuration);
+        $this->setCommandTimeout($configuration);
         $this->setExecutableStores();
         $this->addStageToConfiguration($commandLineOptionContainer->getRecipe(), $configuration['sections']);
 
@@ -139,6 +141,18 @@ class ConfigurationBuilder implements ConfigurationBuilderInterface
     {
         if (isset($configuration[static::CONFIG_STORES])) {
             $this->configuration->setStores($configuration[static::CONFIG_STORES]);
+        }
+    }
+
+    /**
+     * @param array $configuration
+     *
+     * @return void
+     */
+    protected function setCommandTimeout(array $configuration)
+    {
+        if (isset($configuration[static::CONFIG_COMMAND_TIMEOUT])) {
+            $this->configuration->setCommandTimeout($configuration[static::CONFIG_COMMAND_TIMEOUT]);
         }
     }
 

--- a/src/Spryker/Install/Configuration/Configuration.php
+++ b/src/Spryker/Install/Configuration/Configuration.php
@@ -191,7 +191,7 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCommandTimeout(): ?int
     {

--- a/src/Spryker/Install/Configuration/Configuration.php
+++ b/src/Spryker/Install/Configuration/Configuration.php
@@ -34,6 +34,11 @@ class Configuration implements ConfigurationInterface
     protected $stores = [];
 
     /**
+     * @var int
+     */
+    protected $commandTimeout;
+
+    /**
      * @var string[]
      */
     protected $executableStores = [];
@@ -171,6 +176,26 @@ class Configuration implements ConfigurationInterface
     public function getStores(): array
     {
         return $this->stores;
+    }
+
+    /**
+     * @param int $commandTimeout
+     *
+     * @return \Spryker\Install\Configuration\ConfigurationInterface
+     */
+    public function setCommandTimeout(int $commandTimeout): ConfigurationInterface
+    {
+        $this->commandTimeout = $commandTimeout;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCommandTimeout(): ?int
+    {
+        return $this->commandTimeout;
     }
 
     /**

--- a/src/Spryker/Install/Configuration/ConfigurationInterface.php
+++ b/src/Spryker/Install/Configuration/ConfigurationInterface.php
@@ -93,7 +93,7 @@ interface ConfigurationInterface
     public function setCommandTimeout(int $commandTimeout): self;
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getCommandTimeout(): ?int;
 

--- a/src/Spryker/Install/Configuration/ConfigurationInterface.php
+++ b/src/Spryker/Install/Configuration/ConfigurationInterface.php
@@ -86,6 +86,18 @@ interface ConfigurationInterface
     public function getStores(): array;
 
     /**
+     * @param int $commandTimeout
+     *
+     * @return $this
+     */
+    public function setCommandTimeout(int $commandTimeout): self;
+
+    /**
+     * @return int
+     */
+    public function getCommandTimeout(): ?int;
+
+    /**
      * @param array $executableStores
      *
      * @return $this

--- a/src/Spryker/Install/Executable/CommandLine/CommandLineExecutable.php
+++ b/src/Spryker/Install/Executable/CommandLine/CommandLineExecutable.php
@@ -16,7 +16,7 @@ use Symfony\Component\Process\Process;
 
 class CommandLineExecutable implements ExecutableInterface
 {
-    const DEFAULT_TIMEOUT_IN_SECONDS = 3600;
+    const DEFAULT_TIMEOUT_IN_SECONDS = 600;
 
     /**
      * @var \Spryker\Install\Stage\Section\Command\CommandInterface
@@ -83,7 +83,7 @@ class CommandLineExecutable implements ExecutableInterface
             return $this->command->getTimeout();
         }
 
-        return static::DEFAULT_TIMEOUT_IN_SECONDS;
+        return $this->configuration->getCommandTimeout() ?: static::DEFAULT_TIMEOUT_IN_SECONDS;
     }
 
     /**

--- a/tests/_data/config/install/timeout.yml
+++ b/tests/_data/config/install/timeout.yml
@@ -1,3 +1,4 @@
+command-timeout: 30
 sections:
   section-a:
     section-a-command-a:


### PR DESCRIPTION
- Developer(s): @tamasnyulas

- Peer Reviewer:

- Ticket: https://spryker.atlassian.net/browse/CORE-4307

- Academy PR:  https://github.com/spryker/madcap.spryker.github.io/pull/307


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department
- [ ] All new or heavily changed classes get an "A" rating (Scrutinizer), except Facades, Factories, QueryContainers and Tests

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Install               | patch (currently 0.x)  |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Install

_**Patch:** Backwards-compatible bug fix_

Def of done (by responsible developer):
- [ ] All changes are backward-compatible. Outdated code is marked as deprecated.
- [ ] The change is isolated and not mixed with any cleanups or other changes.
- [ ] New code fits to the architecture rules.
- [ ] All new or changed business logic is covered by functional tests (in Zed business layer).

##### Change log

Bugfixes

- Default command timeout was reverted to 600 seconds.
- Command timeout can be configured for all commands per recipe.
