### PR TITLE
Update phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
   "require-dev": {
     "codeception/codeception": "*",
     "symfony/var-dumper": "^3.0.0",
-    "phpstan/phpstan": "^0.10.0",
-    "spryker/code-sniffer": "dev-master as 1.0.0",
+    "phpstan/phpstan": "^0.11.2",
+    "spryker/code-sniffer": "*",
     "php-coveralls/php-coveralls": "^1.0"
   },
   "autoload": {

--- a/src/Spryker/Console/InstallConsoleCommand.php
+++ b/src/Spryker/Console/InstallConsoleCommand.php
@@ -105,7 +105,7 @@ class InstallConsoleCommand extends Command
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return void
+     * @return int|null
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -117,6 +117,8 @@ class InstallConsoleCommand extends Command
             $this->getCommandLineOptionContainer(),
             $this->output
         );
+
+        return 0;
     }
 
     /**

--- a/src/Spryker/Style/InputHelper.php
+++ b/src/Spryker/Style/InputHelper.php
@@ -28,11 +28,11 @@ trait InputHelper
      * @param string $question
      * @param bool $default
      *
-     * @return string
+     * @return bool
      */
     public function confirm($question, $default)
     {
-        return $this->askQuestion(new ConfirmationQuestion($question, $default));
+        return (bool)$this->askQuestion(new ConfirmationQuestion($question, $default));
     }
 
     /**


### PR DESCRIPTION
```
------ ----------------------------------------------------------------------- 
  Line   Spryker/Console/InstallConsoleCommand.php                              
 ------ ----------------------------------------------------------------------- 
  110    Return type (void) of method                                           
         Spryker\Console\InstallConsoleCommand::execute() should be compatible  
         with return type (int|null) of method                                  
         Symfony\Component\Console\Command\Command::execute()                   
 ------ ----------------------------------------------------------------------- 
 ------ -------------------------------------------------------------------------------- 
  Line   Spryker/Style/InputHelper.php (in context of class Spryker\Style\SprykerStyle)  
 ------ -------------------------------------------------------------------------------- 
  33     Return type (string) of method Spryker\Style\SprykerStyle::confirm()            
         should be compatible with return type (bool) of method                          
         Spryker\Style\StyleInterface::confirm()                                         
 ------ -------------------------------------------------------------------------------- 
```