### PR TITLE
Use console_env_local if exists and APPLICATION_ENV not set by server.

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,3 +1,4 @@
 <?php
 
 define('SPRYKER_ROOT', __DIR__);
+define('APPLICATION_ROOT_DIR', __DIR__);

--- a/src/Spryker/Console/InstallConsoleCommand.php
+++ b/src/Spryker/Console/InstallConsoleCommand.php
@@ -261,7 +261,15 @@ class InstallConsoleCommand extends Command
      */
     protected function getEnvironment()
     {
-        $environment = (getenv('APPLICATION_ENV') ? getenv('APPLICATION_ENV') : 'production');
+        $environment = getenv('APPLICATION_ENV', true) ?: getenv('APPLICATION_ENV');
+
+        if (!$environment && file_exists(APPLICATION_ROOT_DIR . '/config/Shared/console_env_local.php')) {
+            $environment = require APPLICATION_ROOT_DIR . '/config/Shared/console_env_local.php';
+        }
+
+        if (!$environment) {
+            $environment = 'production';
+        }
 
         return (string)$environment;
     }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,3 +1,4 @@
 <?php
 
 defined('SPRYKER_ROOT') || define('SPRYKER_ROOT', __DIR__ . '/_data');
+defined('APPLICATION_ROOT_DIR') || define('APPLICATION_ROOT_DIR', __DIR__ . '/_data');


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: TICKET_URL_HERE

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Install               | patch (currently 0.x)  |                       |

#### Release Notes

Previously, we changed our default from using `development` to use `production` as the default environment for the installation process. For developers which are using and older devvm this leads to the problem that they used the `production` environment. In those cases, the developers needed to use `-r development` to tell the install tool that it have to use the  `development` environment.

-----------------------------------------

#### Module Install

##### Change log

Bugfixes

- Added usage of the `console_env_local.php` file as fallback for older devvm's.

