### PR TITLE
TE-7001 Updated Symfony console commands to always return int.

### DIFF
--- a/src/Spryker/Console/InstallConsoleCommand.php
+++ b/src/Spryker/Console/InstallConsoleCommand.php
@@ -100,9 +100,9 @@ class InstallConsoleCommand extends Command
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      *
-     * @return int|null
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->input = $input;
         $this->output = $this->createOutput($input, $output);


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-7001

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/2897


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Install               | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Install

##### Change log

Fixes

- Always return `int` for console command.

